### PR TITLE
Specify propertiesFilename in ant script

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -152,7 +152,7 @@ Valid values are:
   </target>
 
   <target description="Make output directories and run the TestBox task" name="run-tests-testbox">
-    <get dest="${output.dir}/results.txt" src="http://${server.name}:${server.port}/${test.project}/tests/ci/testbox-runner.cfm?directory=${testbox.directory}&amp;reporter=text&amp;reportPath=${basedir}/${output.dir}" verbose="true" />
+    <get dest="${output.dir}/results.txt" src="http://${server.name}:${server.port}/${test.project}/tests/ci/testbox-runner.cfm?directory=${testbox.directory}&amp;reporter=text&amp;reportPath=${basedir}/${output.dir}&amp;propertiesFilename=testbox.properties" verbose="true" />
     <concat><path path="${output.dir}/output.txt" /></concat>
   </target>
 


### PR DESCRIPTION
It looks like the script is expecting the properties file to be named testbox.properties (line 142) but the default name of the file is TEST.properties so I am passing it into the url.
