### PR TITLE
Fix cfml-ci for testbox

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -153,6 +153,7 @@ Valid values are:
 
   <target description="Make output directories and run the TestBox task" name="run-tests-testbox">
     <get dest="${output.dir}/results.txt" src="http://${server.name}:${server.port}/${test.project}/tests/ci/testbox-runner.cfm?directory=${testbox.directory}&amp;reporter=text&amp;reportPath=${basedir}/${output.dir}" verbose="true" />
+    <concat><path path="${output.dir}/results.txt" /></concat>
     <concat><path path="${output.dir}/output.txt" /></concat>
   </target>
 

--- a/build.xml
+++ b/build.xml
@@ -152,7 +152,7 @@ Valid values are:
   </target>
 
   <target description="Make output directories and run the TestBox task" name="run-tests-testbox">
-    <get dest="${output.dir}/results.txt" src="http://${server.name}:${server.port}/${test.project}/tests/ci/testbox-runner.cfm?directory=${testbox.directory}&amp;reporter=text&amp;reportPath=${basedir}/${output.dir}" verbose="true" />
+    <get dest="${output.dir}/results.txt" src="http://${server.name}:${server.port}/${test.project}/tests/ci/testbox-runner.cfm?directory=${testbox.directory}&amp;reporter=text&amp;reportPath=${basedir}/${output.dir}&amp;propertiesSummary=true&amp;propertiesFilename=testbox.properties" verbose="true" />
     <concat><path path="${output.dir}/testbox.properties" /></concat>
     <concat><path path="${output.dir}/results.txt" /></concat>
     <concat><path path="${output.dir}/output.txt" /></concat>

--- a/build.xml
+++ b/build.xml
@@ -140,7 +140,7 @@ Valid values are:
     <fail if="mxunit.failed" message="At least one test failure!"/>
 
     <property file="${output.dir}/testbox.properties" />
-    <fail if="testbox.failed" message="At least one test failure!" />
+    <fail if="test.failed" message="At least one test failure!" />
   </target>
 
   <target name="test">

--- a/build.xml
+++ b/build.xml
@@ -153,6 +153,7 @@ Valid values are:
 
   <target description="Make output directories and run the TestBox task" name="run-tests-testbox">
     <get dest="${output.dir}/results.txt" src="http://${server.name}:${server.port}/${test.project}/tests/ci/testbox-runner.cfm?directory=${testbox.directory}&amp;reporter=text&amp;reportPath=${basedir}/${output.dir}" verbose="true" />
+    <concat><path path="${output.dir}/testbox.properties" /></concat>
     <concat><path path="${output.dir}/results.txt" /></concat>
     <concat><path path="${output.dir}/output.txt" /></concat>
   </target>

--- a/build.xml
+++ b/build.xml
@@ -155,7 +155,6 @@ Valid values are:
     <get dest="${output.dir}/results.txt" src="http://${server.name}:${server.port}/${test.project}/tests/ci/testbox-runner.cfm?directory=${testbox.directory}&amp;reporter=text&amp;reportPath=${basedir}/${output.dir}&amp;propertiesSummary=true&amp;propertiesFilename=testbox.properties" verbose="true" />
     <concat><path path="${output.dir}/testbox.properties" /></concat>
     <concat><path path="${output.dir}/results.txt" /></concat>
-    <concat><path path="${output.dir}/output.txt" /></concat>
   </target>
 
   <target description="Make output directories and run the MXUnit task" name="run-tests-mxunit">

--- a/build.xml
+++ b/build.xml
@@ -139,7 +139,7 @@ Valid values are:
   <target name="test-ci" depends="start-server,test,stop-server">
     <fail if="mxunit.failed" message="At least one test failure!"/>
 
-    <property file="${output.dir}testbox.properties" />
+    <property file="${output.dir}/testbox.properties" />
     <fail if="testbox.failed" message="At least one test failure!" />
   </target>
 


### PR DESCRIPTION
There were a few things that were incorrect with respect to the testbox integration in cfml-ci.
- testbox creates `TEST.properties` not `testbox.properties` by default
- It was looking for `testbox.failed` in the `testbox.properties` file, but testbox defines `test.failed` instead
- It had `propertiesSummary=false` by default, passed in true so it actually generates the .properties file.
